### PR TITLE
Export `solve_blocks` for creating `.h5` formatted LD files

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,39 @@
 
 julia_version = "1.9.0"
 manifest_format = "2.0"
-project_hash = "3e89a5e1700891d6496ca8c345eefc8b4a458209"
+project_hash = "d701dbb564dd157b3aed7cd40b9cae46c20fb4c8"
+
+[[deps.AbstractFFTs]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.5.0"
+weakdeps = ["ChainRulesCore", "Test"]
+
+    [deps.AbstractFFTs.extensions]
+    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
+    AbstractFFTsTestExt = "Test"
+
+[[deps.Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Markdown", "Test"]
+git-tree-sha1 = "c0d491ef0b135fd7d63cbc6404286bc633329425"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.36"
+
+    [deps.Accessors.extensions]
+    AccessorsAxisKeysExt = "AxisKeys"
+    AccessorsIntervalSetsExt = "IntervalSets"
+    AccessorsStaticArraysExt = "StaticArrays"
+    AccessorsStructArraysExt = "StructArrays"
+    AccessorsUnitfulExt = "Unitful"
+
+    [deps.Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
@@ -49,8 +81,61 @@ version = "7.4.5"
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
+[[deps.Automa]]
+deps = ["TranscodingStreams"]
+git-tree-sha1 = "ef9997b3d5547c48b41c7bd8899e812a917b409d"
+uuid = "67c07d97-cdcb-5c2c-af73-a7f9c32a568b"
+version = "0.8.4"
+
+[[deps.BGZFStreams]]
+deps = ["CodecZlib"]
+git-tree-sha1 = "3aca54d25f8c30056577aa37ea68184da68df685"
+uuid = "28d598bf-9b8f-59f1-b38c-5a06b4a0f5e6"
+version = "0.3.2"
+
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "f1dff6729bc61f4d49e140da1af55dcd1ac97b2f"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.5.0"
+
+[[deps.BioGenerics]]
+deps = ["TranscodingStreams"]
+git-tree-sha1 = "7bbc085aebc6faa615740b63756e4986c9e85a70"
+uuid = "47718e42-2ac5-11e9-14af-e5595289c2ea"
+version = "0.1.4"
+
+[[deps.BitTwiddlingConvenienceFunctions]]
+deps = ["Static"]
+git-tree-sha1 = "0c5f81f47bbbcf4aea7b2959135713459170798b"
+uuid = "62783981-4cbd-42fc-bca8-16325de8dc4b"
+version = "0.1.5"
+
+[[deps.BlockDiagonals]]
+deps = ["ChainRulesCore", "FillArrays", "FiniteDifferences", "LinearAlgebra"]
+git-tree-sha1 = "920d3775e35c519a2aced9e7bbe9ac61218eeead"
+uuid = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
+version = "0.1.42"
+
+[[deps.BufferedStreams]]
+git-tree-sha1 = "4ae47f9a4b1dc19897d3743ff13685925c5202ec"
+uuid = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
+version = "1.2.1"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "9e2a6b69137e6969bab0152632dcb3bc108c8bdd"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.8+1"
+
+[[deps.CPUSummary]]
+deps = ["CpuId", "IfElse", "PrecompileTools", "Static"]
+git-tree-sha1 = "585a387a490f1c4bd88be67eea15b93da5e85db7"
+uuid = "2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+version = "0.2.5"
 
 [[deps.CSV]]
 deps = ["CodecZlib", "Dates", "FilePathsBase", "InlineStrings", "Mmap", "Parsers", "PooledArrays", "PrecompileTools", "SentinelArrays", "Tables", "Unicode", "WeakRefStrings", "WorkerUtilities"]
@@ -64,11 +149,61 @@ git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
 uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 version = "0.5.1"
 
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra"]
+git-tree-sha1 = "71acdbf594aab5bbb2cec89b208c41b4c411e49f"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.24.0"
+weakdeps = ["SparseArrays"]
+
+    [deps.ChainRulesCore.extensions]
+    ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.CloseOpenIntervals]]
+deps = ["Static", "StaticArrayInterface"]
+git-tree-sha1 = "70232f82ffaab9dc52585e0dd043b5e0c6b714f1"
+uuid = "fb6a15b2-703c-40df-9091-08a04967cfa9"
+version = "0.1.12"
+
+[[deps.Clustering]]
+deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "Random", "SparseArrays", "Statistics", "StatsBase"]
+git-tree-sha1 = "9ebb045901e9bbf58767a9f34ff89831ed711aae"
+uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
+version = "0.15.7"
+
+[[deps.CodecBzip2]]
+deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
+git-tree-sha1 = "9b1ca1aa6ce3f71b3d1840c538a8210a043625eb"
+uuid = "523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+version = "0.8.2"
+
+[[deps.CodecXz]]
+deps = ["Libdl", "TranscodingStreams", "XZ_jll"]
+git-tree-sha1 = "893153d91e4b7af48bbe394d6094451938390aba"
+uuid = "ba30903b-d9e8-5048-a5ec-d1f5b0d4b47b"
+version = "0.7.2"
+
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
 git-tree-sha1 = "9c209fb7536406834aa938fb149964b985de6c83"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.1"
+
+[[deps.CodecZstd]]
+deps = ["TranscodingStreams", "Zstd_jll"]
+git-tree-sha1 = "0d0612d8646ed6157adaceff420b3bacbc2510a9"
+uuid = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+version = "0.8.3"
+
+[[deps.Combinatorics]]
+git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
+uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+version = "1.0.2"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.4"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools", "Test"]
@@ -91,6 +226,15 @@ deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "1.0.2+0"
 
+[[deps.CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [deps.CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
 [[deps.ConstructionBase]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "738fec4d684a9a6ee9598a8bfee305b26831f28c"
@@ -104,6 +248,18 @@ version = "1.5.2"
     [deps.ConstructionBase.weakdeps]
     IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[[deps.CovarianceEstimation]]
+deps = ["LinearAlgebra", "Statistics", "StatsBase", "TSVD", "WoodburyMatrices"]
+git-tree-sha1 = "8755768c0bae7dfa5c10f16bb8d04bfc98df2aaa"
+uuid = "587fd27a-f159-11e8-2dae-1979310e6154"
+version = "0.2.12"
+
+[[deps.CpuId]]
+deps = ["Markdown"]
+git-tree-sha1 = "fcbb72b032692610bfbdb15018ac16a36cf2e406"
+uuid = "adafc99b-e345-5852-983c-f28acb93d879"
+version = "0.3.1"
 
 [[deps.Crayons]]
 git-tree-sha1 = "249fe38abf76d48563e2f4556bebd215aa317e15"
@@ -160,6 +316,17 @@ git-tree-sha1 = "a4ad7ef19d2cdc2eff57abbbe68032b1cd0bd8f8"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
 version = "1.13.0"
 
+[[deps.Distances]]
+deps = ["LinearAlgebra", "Statistics", "StatsAPI"]
+git-tree-sha1 = "66c4c81f259586e8f002eacebc177e1fb06363b0"
+uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+version = "0.10.11"
+weakdeps = ["ChainRulesCore", "SparseArrays"]
+
+    [deps.Distances.extensions]
+    DistancesChainRulesCoreExt = "ChainRulesCore"
+    DistancesSparseArraysExt = "SparseArrays"
+
 [[deps.Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
@@ -195,6 +362,24 @@ git-tree-sha1 = "5837a837389fccf076445fce071c8ddaea35a566"
 uuid = "fa6b7ba4-c1ee-5f82-b5fc-ecf0adba8f74"
 version = "0.6.8"
 
+[[deps.ElasticArrays]]
+deps = ["Adapt"]
+git-tree-sha1 = "75e5697f521c9ab89816d3abeea806dfc5afb967"
+uuid = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
+version = "1.2.12"
+
+[[deps.FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
+git-tree-sha1 = "4820348781ae578893311153d69049a93d05f39d"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.8.0"
+
+[[deps.FFTW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.10+0"
+
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates", "Mmap", "Printf", "Test", "UUIDs"]
 git-tree-sha1 = "e27c4ebe80e8699540f2d6c805cc12203b614f12"
@@ -216,6 +401,12 @@ git-tree-sha1 = "6604e18a0220650dbbea7854938768f15955dd8e"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
 version = "2.20.0"
 
+[[deps.FiniteDifferences]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Printf", "Random", "Richardson", "SparseArrays", "StaticArrays"]
+git-tree-sha1 = "06d76c780d657729cf20821fb5832c6cc4dfd0b5"
+uuid = "26cc04aa-876d-5657-8c51-4c34ba976000"
+version = "0.12.32"
+
 [[deps.Formatting]]
 deps = ["Printf"]
 git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
@@ -236,6 +427,24 @@ weakdeps = ["StaticArrays"]
 deps = ["Random"]
 uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
+[[deps.GLM]]
+deps = ["Distributions", "LinearAlgebra", "Printf", "Reexport", "SparseArrays", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns", "StatsModels"]
+git-tree-sha1 = "97829cfda0df99ddaeaafb5b370d6cab87b7013e"
+uuid = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
+version = "1.8.3"
+
+[[deps.GLMNet]]
+deps = ["DataFrames", "Distributed", "Distributions", "Printf", "Random", "SparseArrays", "StatsBase", "glmnet_jll"]
+git-tree-sha1 = "7ea4e2bbb84183fe52a488d05e16c152b2387b95"
+uuid = "8d5ece8b-de18-5317-b113-243142960cc6"
+version = "0.7.2"
+
+[[deps.GenericLinearAlgebra]]
+deps = ["LinearAlgebra", "Printf", "Random", "libblastrampoline_jll"]
+git-tree-sha1 = "02be7066f936af6b04669f7c370a31af9036c440"
+uuid = "14197337-ba66-59df-a3e3-ca00e7dcff7a"
+version = "0.3.11"
+
 [[deps.Ghostbasil]]
 deps = ["CxxWrap", "ghostbasil_jll", "libcxxwrap_julia_jll"]
 git-tree-sha1 = "96f7174a274905ecfd4d72cd5bd389dd6ae97136"
@@ -243,6 +452,11 @@ repo-rev = "main"
 repo-url = "https://github.com/biona001/Ghostbasil.jl"
 uuid = "42a9b20f-2d23-465a-b7ed-975dbff4a4d6"
 version = "0.0.1"
+
+[[deps.Glob]]
+git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
+uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
+version = "1.3.1"
 
 [[deps.HDF5]]
 deps = ["Compat", "HDF5_jll", "Libdl", "MPIPreferences", "Mmap", "Preferences", "Printf", "Random", "UUIDs"]
@@ -264,11 +478,23 @@ git-tree-sha1 = "e4591176488495bf44d7456bd73179d87d5e6eab"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
 version = "1.14.3+1"
 
+[[deps.HostCPUFeatures]]
+deps = ["BitTwiddlingConvenienceFunctions", "IfElse", "Libdl", "Static"]
+git-tree-sha1 = "eb8fed28f4994600e29beef49744639d985a04b2"
+uuid = "3e5b6fbb-0976-4d2c-9146-d79de83f2fb0"
+version = "0.1.16"
+
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "ca0f6bf568b4bfc807e7537f081c81e35ceca114"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
 version = "2.10.0+0"
+
+[[deps.Hypatia]]
+deps = ["Combinatorics", "DocStringExtensions", "GenericLinearAlgebra", "IterativeSolvers", "LinearAlgebra", "LinearMaps", "MathOptInterface", "PolynomialRoots", "Printf", "Requires", "SparseArrays", "SpecialFunctions", "SuiteSparse", "Test"]
+git-tree-sha1 = "b31ac75a6e5747cdea4c1c6c0d4f8c66721eae3c"
+uuid = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
+version = "0.7.4"
 
 [[deps.HypergeometricFunctions]]
 deps = ["DualNumbers", "LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
@@ -276,15 +502,42 @@ git-tree-sha1 = "84204eae2dd237500835990bcade263e27674a93"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 version = "0.3.16"
 
+[[deps.HypothesisTests]]
+deps = ["Combinatorics", "Distributions", "LinearAlgebra", "Printf", "Random", "Rmath", "Roots", "Statistics", "StatsAPI", "StatsBase"]
+git-tree-sha1 = "4b5d5ba51f5f473737ed9de6d8a7aa190ad8c72f"
+uuid = "09f84164-cd44-5f33-b23f-e6b0d136a0d5"
+version = "0.11.0"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
 [[deps.InlineStrings]]
 deps = ["Parsers"]
 git-tree-sha1 = "9cc2baf75c6d09f9da536ddf58eb2f29dedaf461"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 version = "1.4.0"
 
+[[deps.IntelOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be50fe8df3acbffa0274a744f1a99d29c45a57f4"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2024.1.0+0"
+
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "e7cbed5032c4c397a6ac23d1493f3289e01231c4"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.14"
+weakdeps = ["Dates"]
+
+    [deps.InverseFunctions.extensions]
+    DatesExt = "Dates"
 
 [[deps.InvertedIndices]]
 git-tree-sha1 = "0dc7b50b8d436461be01300fd8cd45aa0274b038"
@@ -295,6 +548,12 @@ version = "1.3.0"
 git-tree-sha1 = "630b497eafcc20001bba38a4651b327dcfc491d2"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
 version = "0.2.2"
+
+[[deps.IterativeSolvers]]
+deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays"]
+git-tree-sha1 = "59545b0a2b27208b0650df0a46b8e3019f85055b"
+uuid = "42fd0dbc-a981-5370-80f2-aaf504508153"
+version = "0.9.4"
 
 [[deps.IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -307,10 +566,40 @@ git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.4.1"
 
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.4"
+
+[[deps.JuMP]]
+deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
+git-tree-sha1 = "7e10a0d8b534f2d8e9f712b33488584254624fb1"
+uuid = "4076af6c-e467-56ae-b986-b466b2749572"
+version = "1.22.2"
+
+    [deps.JuMP.extensions]
+    JuMPDimensionalDataExt = "DimensionalData"
+
+    [deps.JuMP.weakdeps]
+    DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
+
+[[deps.Knockoffs]]
+deps = ["BlockDiagonals", "CSV", "Clustering", "CovarianceEstimation", "DataFrames", "DelimitedFiles", "Distributions", "Downloads", "ElasticArrays", "GLM", "GLMNet", "Hypatia", "JuMP", "LinearAlgebra", "LoopVectorization", "LowRankApprox", "Optim", "PositiveFactorizations", "ProgressMeter", "Random", "Reexport", "Roots", "SnpArrays", "Statistics", "StatsBase"]
+git-tree-sha1 = "81b3dc08399cd95282792920dd2fcf9b9e7a6fc5"
+uuid = "878bf26d-0c49-448a-9df5-b057c815d613"
+version = "1.1.11"
+
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.3.0"
+
+[[deps.LayoutPointers]]
+deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static", "StaticArrayInterface"]
+git-tree-sha1 = "62edfee3211981241b57ff1cedf4d74d79519277"
+uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
+version = "0.1.15"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -348,6 +637,18 @@ version = "7.2.0"
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
+[[deps.LinearMaps]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "9948d6f8208acfebc3e8cf4681362b2124339e7e"
+uuid = "7a12625a-238d-50fd-b39a-03d52299707e"
+version = "3.11.2"
+weakdeps = ["ChainRulesCore", "SparseArrays", "Statistics"]
+
+    [deps.LinearMaps.extensions]
+    LinearMapsChainRulesCoreExt = "ChainRulesCore"
+    LinearMapsSparseArraysExt = "SparseArrays"
+    LinearMapsStatisticsExt = "Statistics"
+
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
 git-tree-sha1 = "0a1b7c2863e44523180fdb3146534e265a91870b"
@@ -366,6 +667,39 @@ version = "0.3.23"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.LoopVectorization]]
+deps = ["ArrayInterface", "CPUSummary", "CloseOpenIntervals", "DocStringExtensions", "HostCPUFeatures", "IfElse", "LayoutPointers", "LinearAlgebra", "OffsetArrays", "PolyesterWeave", "PrecompileTools", "SIMDTypes", "SLEEFPirates", "Static", "StaticArrayInterface", "ThreadingUtilities", "UnPack", "VectorizationBase"]
+git-tree-sha1 = "8f6786d8b2b3248d79db3ad359ce95382d5a6df8"
+uuid = "bdcacae8-1622-11e9-2a5c-532679323890"
+version = "0.12.170"
+weakdeps = ["ChainRulesCore", "ForwardDiff", "SpecialFunctions"]
+
+    [deps.LoopVectorization.extensions]
+    ForwardDiffExt = ["ChainRulesCore", "ForwardDiff"]
+    SpecialFunctionsExt = "SpecialFunctions"
+
+[[deps.LowRankApprox]]
+deps = ["FFTW", "LinearAlgebra", "LowRankMatrices", "Nullables", "Random", "SparseArrays"]
+git-tree-sha1 = "031af63ba945e23424815014ba0e59c28f5aed32"
+uuid = "898213cb-b102-5a47-900c-97e73b919f73"
+version = "0.5.5"
+
+[[deps.LowRankMatrices]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "7c8664b2f3d5c3d9b77605c03d53b18813e79b0f"
+uuid = "e65ccdef-c354-471a-8090-89bec1c20ec3"
+version = "1.0.1"
+weakdeps = ["FillArrays"]
+
+    [deps.LowRankMatrices.extensions]
+    LowRankMatricesFillArraysExt = "FillArrays"
+
+[[deps.MKL_jll]]
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
+git-tree-sha1 = "80b2833b56d466b3858d565adcd16a4a05f2089b"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2024.1.0+0"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
@@ -391,9 +725,20 @@ git-tree-sha1 = "42324d08725e200c23d4dfb549e0d5d89dede2d2"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.10"
 
+[[deps.ManualMemory]]
+git-tree-sha1 = "bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd"
+uuid = "d125e4d3-2237-4719-b19c-fa641b8a4667"
+version = "0.1.8"
+
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MathOptInterface]]
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test", "Unicode"]
+git-tree-sha1 = "fffbbdbc10ba66885b7b4c06f4bd2c0efc5813d6"
+uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+version = "1.30.0"
 
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -419,6 +764,12 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2022.10.11"
 
+[[deps.MutableArithmetics]]
+deps = ["LinearAlgebra", "SparseArrays", "Test"]
+git-tree-sha1 = "898c56fbf8bf71afb0c02146ef26f3a454e88873"
+uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+version = "1.4.5"
+
 [[deps.NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
 git-tree-sha1 = "a0b464d183da839699f4c79e7606d9d186ec172c"
@@ -431,9 +782,29 @@ git-tree-sha1 = "0877504529a3e5c3343c6f8b4c0381e57e4387e4"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "1.0.2"
 
+[[deps.NearestNeighbors]]
+deps = ["Distances", "StaticArrays"]
+git-tree-sha1 = "91a67b4d73842da90b526011fa85c5c4c9343fe0"
+uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+version = "0.4.18"
+
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
+
+[[deps.Nullables]]
+git-tree-sha1 = "8f87854cc8f3685a60689d8edecaa29d2251979b"
+uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
+version = "1.0.0"
+
+[[deps.OffsetArrays]]
+git-tree-sha1 = "e64b4f5ea6b7389f6f046d13d4896a8f9c1ba71e"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.14.0"
+weakdeps = ["Adapt"]
+
+    [deps.OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
@@ -497,6 +868,17 @@ deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 version = "1.9.0"
 
+[[deps.PolyesterWeave]]
+deps = ["BitTwiddlingConvenienceFunctions", "CPUSummary", "IfElse", "Static", "ThreadingUtilities"]
+git-tree-sha1 = "240d7170f5ffdb285f9427b92333c3463bf65bf6"
+uuid = "1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+version = "0.2.1"
+
+[[deps.PolynomialRoots]]
+git-tree-sha1 = "5f807b5345093487f733e520a1b7395ee9324825"
+uuid = "3a141323-8675-5d76-9d11-e1df1406c778"
+version = "1.0.0"
+
 [[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
 git-tree-sha1 = "a6062fe4063cdafe78f4a0a81cfffb89721b30e7"
@@ -531,6 +913,16 @@ version = "2.2.4"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[deps.Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[deps.ProgressMeter]]
+deps = ["Distributed", "Printf"]
+git-tree-sha1 = "763a8ceb07833dd51bb9e3bbca372de32c0605ad"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "1.10.0"
+
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
 git-tree-sha1 = "6ec7ac8412e83d57e313393220879ede1740f9ee"
@@ -545,6 +937,12 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -555,6 +953,12 @@ deps = ["UUIDs"]
 git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
 version = "1.3.0"
+
+[[deps.Richardson]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "48f038bfd83344065434089c2a79417f38715c41"
+uuid = "708f8203-808e-40c0-ba2d-98a6953ed40d"
+version = "1.4.2"
 
 [[deps.Rmath]]
 deps = ["Random", "Rmath_jll"]
@@ -568,9 +972,38 @@ git-tree-sha1 = "6ed52fdd3382cf21947b15e8870ac0ddbff736da"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
 version = "0.4.0+0"
 
+[[deps.Roots]]
+deps = ["Accessors", "ChainRulesCore", "CommonSolve", "Printf"]
+git-tree-sha1 = "1ab580704784260ee5f45bffac810b152922747b"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "2.1.5"
+
+    [deps.Roots.extensions]
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+
+    [deps.Roots.weakdeps]
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
+
+[[deps.SIMDTypes]]
+git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
+uuid = "94e857df-77ce-4151-89e5-788b33177be4"
+version = "0.1.0"
+
+[[deps.SLEEFPirates]]
+deps = ["IfElse", "Static", "VectorizationBase"]
+git-tree-sha1 = "3aac6d68c5e57449f5b9b865c9ba50ac2970c4cf"
+uuid = "476501e8-09a2-5ece-8869-fb82de89a1fa"
+version = "0.6.42"
 
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
@@ -587,11 +1020,22 @@ git-tree-sha1 = "e2cc6d8c88613c05e1defb55170bf5ff211fbeac"
 uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 version = "1.1.1"
 
+[[deps.ShiftedArrays]]
+git-tree-sha1 = "503688b59397b3307443af35cd953a13e8005c16"
+uuid = "1277b4bf-5013-50f5-be3d-901d8477a67a"
+version = "2.0.0"
+
 [[deps.SnoopPrecompile]]
 deps = ["Preferences"]
 git-tree-sha1 = "e760a70afdcd461cf01a575947738d359234665c"
 uuid = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 version = "1.0.3"
+
+[[deps.SnpArrays]]
+deps = ["Adapt", "CSV", "CodecBzip2", "CodecXz", "CodecZlib", "CodecZstd", "DataFrames", "DelimitedFiles", "Glob", "LinearAlgebra", "LoopVectorization", "Missings", "Mmap", "Printf", "Random", "Requires", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "Tables", "TranscodingStreams", "VariantCallFormat", "VectorizationBase"]
+git-tree-sha1 = "d81de62a0acdbfd7d7ff3d64403eccf06c2fe986"
+uuid = "4e780e97-f5bf-4111-9dc4-b70aaf691b06"
+version = "0.3.21"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -611,12 +1055,27 @@ deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_j
 git-tree-sha1 = "ef28127915f4229c971eb43f3fc075dd3fe91880"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "2.2.0"
+weakdeps = ["ChainRulesCore"]
 
     [deps.SpecialFunctions.extensions]
     SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
 
-    [deps.SpecialFunctions.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+[[deps.Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "b366eb1eb68075745777d80861c6706c33f588ae"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.8.9"
+
+[[deps.StaticArrayInterface]]
+deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Requires", "SparseArrays", "Static", "SuiteSparse"]
+git-tree-sha1 = "5d66818a39bb04bf328e92bc933ec5b4ee88e436"
+uuid = "0d7ed370-da01-4f52-bd93-41d350b8b718"
+version = "1.5.0"
+weakdeps = ["OffsetArrays", "StaticArrays"]
+
+    [deps.StaticArrayInterface.extensions]
+    StaticArrayInterfaceOffsetArraysExt = "OffsetArrays"
+    StaticArrayInterfaceStaticArraysExt = "StaticArrays"
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
@@ -651,14 +1110,17 @@ deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Re
 git-tree-sha1 = "f625d686d5a88bcd2b15cd81f18f98186fdc0c9a"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 version = "1.3.0"
+weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
     [deps.StatsFuns.extensions]
     StatsFunsChainRulesCoreExt = "ChainRulesCore"
     StatsFunsInverseFunctionsExt = "InverseFunctions"
 
-    [deps.StatsFuns.weakdeps]
-    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+[[deps.StatsModels]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Printf", "REPL", "ShiftedArrays", "SparseArrays", "StatsBase", "StatsFuns", "Tables"]
+git-tree-sha1 = "8cc7a5385ecaa420f0b3426f9b0135d0df0638ed"
+uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
+version = "0.7.2"
 
 [[deps.StringManipulation]]
 git-tree-sha1 = "46da2434b41f41ac3594ee9816ce5541c6096123"
@@ -678,6 +1140,12 @@ version = "5.10.1+6"
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
+
+[[deps.TSVD]]
+deps = ["Adapt", "LinearAlgebra"]
+git-tree-sha1 = "c39caef6bae501e5607a6caf68dd9ac6e8addbcb"
+uuid = "9449cd9e-2762-5aa3-a617-5413e99d722e"
+version = "0.4.4"
 
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -705,6 +1173,12 @@ git-tree-sha1 = "9250ef9b01b66667380cf3275b3f7488d0e25faf"
 uuid = "b718987f-49a8-5099-9789-dcd902bef87d"
 version = "1.0.1"
 
+[[deps.ThreadingUtilities]]
+deps = ["ManualMemory"]
+git-tree-sha1 = "eda08f7e9818eb53661b3deb74e3159460dfbc27"
+uuid = "8290d209-cae3-49c0-8002-c8c24d57dab5"
+version = "0.5.2"
+
 [[deps.TranscodingStreams]]
 deps = ["Random", "Test"]
 git-tree-sha1 = "9a6ae7ed916312b41236fcef7e0af564ef934769"
@@ -723,21 +1197,57 @@ version = "1.0.2"
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[deps.VCFTools]]
+deps = ["CodecZlib", "Dates", "DelimitedFiles", "Distributions", "HypothesisTests", "ProgressMeter", "SpecialFunctions", "VariantCallFormat"]
+git-tree-sha1 = "5d4f34655c23019ac3252bbc17ea10113a69d26e"
+uuid = "a620830f-fdd7-5ebc-8d26-3621ab35fbfe"
+version = "0.2.10"
+
+[[deps.VariantCallFormat]]
+deps = ["Automa", "BGZFStreams", "BioGenerics", "BufferedStreams"]
+git-tree-sha1 = "96fbe09c9e3b488666c883772fed8f6c1256c714"
+uuid = "28eba6e3-a997-4ad9-87c6-d933b8bca6c1"
+version = "0.5.6"
+
+[[deps.VectorizationBase]]
+deps = ["ArrayInterface", "CPUSummary", "HostCPUFeatures", "IfElse", "LayoutPointers", "Libdl", "LinearAlgebra", "SIMDTypes", "Static", "StaticArrayInterface"]
+git-tree-sha1 = "e863582a41c5731f51fd050563ae91eb33cf09be"
+uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
+version = "0.21.68"
+
 [[deps.WeakRefStrings]]
 deps = ["DataAPI", "InlineStrings", "Parsers"]
 git-tree-sha1 = "b1be2855ed9ed8eac54e5caff2afcdb442d52c23"
 uuid = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 version = "1.4.2"
 
+[[deps.WoodburyMatrices]]
+deps = ["LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "c1a7aa6219628fcd757dede0ca95e245c5cd9511"
+uuid = "efce3f68-66dc-5838-9240-27a6d6f5f9b6"
+version = "1.0.0"
+
 [[deps.WorkerUtilities]]
 git-tree-sha1 = "cd1659ba0d57b71a464a29e64dbc67cfe83d54e7"
 uuid = "76eceee3-57b5-4d4a-8e66-0e911cebbf60"
 version = "1.6.1"
 
+[[deps.XZ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ac88fb95ae6447c8dda6a5503f3bafd496ae8632"
+uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+version = "5.4.6+0"
+
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.13+0"
+
+[[deps.Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e678132f07ddb5bfa46857f0d7620fb9be675d3b"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.6+0"
 
 [[deps.ghostbasil_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "libcxxwrap_julia_jll"]
@@ -746,6 +1256,12 @@ repo-rev = "main"
 repo-url = "https://github.com/biona001/ghostbasil_jll.jl"
 uuid = "caeec347-1c5e-53ac-8e86-7f5e1a690164"
 version = "0.0.15+0"
+
+[[deps.glmnet_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "31adae3b983b579a1fbd7cfd43a4bc0d224c2f5a"
+uuid = "78c6b45d-5eaf-5d68-bcfb-a5a2cb06c27f"
+version = "2.0.13+0"
 
 [[deps.libaec_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -768,6 +1284,12 @@ version = "0.11.2+0"
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.48.0+0"
+
+[[deps.oneTBB_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7d0ea0f4895ef2f5cb83645fa689e52cb55cf493"
+uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
+version = "2021.12.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,18 +2,7 @@
 
 julia_version = "1.9.0"
 manifest_format = "2.0"
-project_hash = "d701dbb564dd157b3aed7cd40b9cae46c20fb4c8"
-
-[[deps.AbstractFFTs]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "d92ad398961a3ed262d8bf04a1a2b8340f915fef"
-uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.5.0"
-weakdeps = ["ChainRulesCore", "Test"]
-
-    [deps.AbstractFFTs.extensions]
-    AbstractFFTsChainRulesCoreExt = "ChainRulesCore"
-    AbstractFFTsTestExt = "Test"
+project_hash = "f6aac61073e6ec569527e33ba4e65765e420fdff"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Markdown", "Test"]
@@ -368,18 +357,6 @@ git-tree-sha1 = "75e5697f521c9ab89816d3abeea806dfc5afb967"
 uuid = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
 version = "1.2.12"
 
-[[deps.FFTW]]
-deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
-git-tree-sha1 = "4820348781ae578893311153d69049a93d05f39d"
-uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.8.0"
-
-[[deps.FFTW_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
-uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.10+0"
-
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates", "Mmap", "Printf", "Test", "UUIDs"]
 git-tree-sha1 = "e27c4ebe80e8699540f2d6c805cc12203b614f12"
@@ -519,12 +496,6 @@ git-tree-sha1 = "9cc2baf75c6d09f9da536ddf58eb2f29dedaf461"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 version = "1.4.0"
 
-[[deps.IntelOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "be50fe8df3acbffa0274a744f1a99d29c45a57f4"
-uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
-version = "2024.1.0+0"
-
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -585,10 +556,12 @@ version = "1.22.2"
     DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 
 [[deps.Knockoffs]]
-deps = ["BlockDiagonals", "CSV", "Clustering", "CovarianceEstimation", "DataFrames", "DelimitedFiles", "Distributions", "Downloads", "ElasticArrays", "GLM", "GLMNet", "Hypatia", "JuMP", "LinearAlgebra", "LoopVectorization", "LowRankApprox", "Optim", "PositiveFactorizations", "ProgressMeter", "Random", "Reexport", "Roots", "SnpArrays", "Statistics", "StatsBase"]
-git-tree-sha1 = "81b3dc08399cd95282792920dd2fcf9b9e7a6fc5"
+deps = ["BlockDiagonals", "CSV", "Clustering", "CovarianceEstimation", "DataFrames", "DelimitedFiles", "Distributions", "Downloads", "ElasticArrays", "GLM", "GLMNet", "Hypatia", "JuMP", "LinearAlgebra", "LoopVectorization", "Optim", "PositiveFactorizations", "ProgressMeter", "Random", "Reexport", "Roots", "SnpArrays", "Statistics", "StatsBase"]
+git-tree-sha1 = "3c7475e56ec93776db96ce59f4cd1cdac81da47f"
+repo-rev = "master"
+repo-url = "https://github.com/biona001/Knockoffs.jl"
 uuid = "878bf26d-0c49-448a-9df5-b057c815d613"
-version = "1.1.11"
+version = "2.0.0"
 
 [[deps.LaTeXStrings]]
 git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
@@ -678,28 +651,6 @@ weakdeps = ["ChainRulesCore", "ForwardDiff", "SpecialFunctions"]
     [deps.LoopVectorization.extensions]
     ForwardDiffExt = ["ChainRulesCore", "ForwardDiff"]
     SpecialFunctionsExt = "SpecialFunctions"
-
-[[deps.LowRankApprox]]
-deps = ["FFTW", "LinearAlgebra", "LowRankMatrices", "Nullables", "Random", "SparseArrays"]
-git-tree-sha1 = "031af63ba945e23424815014ba0e59c28f5aed32"
-uuid = "898213cb-b102-5a47-900c-97e73b919f73"
-version = "0.5.5"
-
-[[deps.LowRankMatrices]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "7c8664b2f3d5c3d9b77605c03d53b18813e79b0f"
-uuid = "e65ccdef-c354-471a-8090-89bec1c20ec3"
-version = "1.0.1"
-weakdeps = ["FillArrays"]
-
-    [deps.LowRankMatrices.extensions]
-    LowRankMatricesFillArraysExt = "FillArrays"
-
-[[deps.MKL_jll]]
-deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
-git-tree-sha1 = "80b2833b56d466b3858d565adcd16a4a05f2089b"
-uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2024.1.0+0"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
@@ -791,11 +742,6 @@ version = "0.4.18"
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
-
-[[deps.Nullables]]
-git-tree-sha1 = "8f87854cc8f3685a60689d8edecaa29d2251979b"
-uuid = "4d1e1d77-625e-5b40-9113-a560ec7a8ecd"
-version = "1.0.0"
 
 [[deps.OffsetArrays]]
 git-tree-sha1 = "e64b4f5ea6b7389f6f046d13d4896a8f9c1ba71e"
@@ -1284,12 +1230,6 @@ version = "0.11.2+0"
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
 version = "1.48.0+0"
-
-[[deps.oneTBB_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "7d0ea0f4895ef2f5cb83645fa689e52cb55cf493"
-uuid = "1317d2d5-d96f-522e-a858-c73665f53c3e"
-version = "2021.12.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GhostKnockoffGWAS"
 uuid = "28dc8d00-4921-4061-9921-3f423e4be5cc"
 authors = ["Benjamin Chu <benchu99@hotmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
@@ -9,17 +9,22 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+ElasticArrays = "fdbdab4c-e67f-52f5-8c3f-e7b388dad3d4"
 Ghostbasil = "42a9b20f-2d23-465a-b7ed-975dbff4a4d6"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
+Knockoffs = "878bf26d-0c49-448a-9df5-b057c815d613"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+VCFTools = "a620830f-fdd7-5ebc-8d26-3621ab35fbfe"
+VariantCallFormat = "28eba6e3-a997-4ad9-87c6-d933b8bca6c1"
 ghostbasil_jll = "caeec347-1c5e-53ac-8e86-7f5e1a690164"
 
 [compat]
 ArgParse = "1.0"
+Knockoffs = "1.1.11"
 CSV = "0.10"
 DataFrames = "1"
 DelimitedFiles = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ghostbasil_jll = "caeec347-1c5e-53ac-8e86-7f5e1a690164"
 
 [compat]
 ArgParse = "1.0"
-Knockoffs = "1.1.11"
+Knockoffs = "2"
 CSV = "0.10"
 DataFrames = "1"
 DelimitedFiles = "1"

--- a/src/GhostKnockoffGWAS.jl
+++ b/src/GhostKnockoffGWAS.jl
@@ -13,11 +13,19 @@ using ArgParse
 using Statistics
 using StatsBase
 
+# needed for solve_blocks()
+using Knockoffs
+using VCFTools
+using VariantCallFormat
+using ElasticArrays
+
 export ghostknockoffgwas,
-    read_zscores
+    read_zscores,
+    solve_blocks
 
 include("ghostbasil_parallel.jl")
 include("utilities.jl")
 include("app.jl")
+include("make_hdf5.jl")
 
 end # module GhostKnockoffGWAS

--- a/src/app.jl
+++ b/src/app.jl
@@ -184,8 +184,8 @@ end
 function julia_solveblock()::Cint
     try
         # read command line arguments
-        vcffile, chr, start_bp, end_bp, outdir, 
-            hg_build, tol, min_maf, min_hwe, method, group_def, group_cor_cutoff, 
+        vcffile, chr, start_bp, end_bp, outdir, hg_build, tol, min_maf, 
+            min_hwe, method, linkage, force_contiguous, group_cor_cutoff, 
             group_rep_cutoff, verbose = parse_solveblock_commandline(true)
 
         println("\n\nWelcome to the `solve_block` module of GhostKnockoffGWAS!")
@@ -200,7 +200,8 @@ function julia_solveblock()::Cint
         println("min_maf          = ", min_maf)
         println("min_hwe          = ", min_hwe)
         println("method           = ", method)
-        println("group_def        = ", group_def)
+        println("linkage          = ", linkage)
+        println("force_contiguous = ", force_contiguous)
         println("group_cor_cutoff = ", group_cor_cutoff)
         println("group_rep_cutoff = ", group_rep_cutoff)
         println("verbose          = ", verbose)
@@ -208,7 +209,7 @@ function julia_solveblock()::Cint
 
         solve_blocks(vcffile, chr, start_bp, end_bp, outdir, 
             hg_build, tol=tol, min_maf=min_maf, min_hwe=min_hwe, 
-            method=method, group_def=group_def, 
+            method=method, linkage=linkage, force_contiguous=force_contiguous,
             group_cor_cutoff=group_cor_cutoff, 
             group_rep_cutoff=group_rep_cutoff, verbose=verbose)
     catch
@@ -271,13 +272,19 @@ function parse_solveblock_commandline(parseargs::Bool)
                 https://arxiv.org/abs/2310.15069"
             default = "maxent"
             arg_type = String
-        "--group_def"
-            help = "method for constructing groups, choices include `hc`
-                (default, average-linkage hierarchical clustering) or `id`
-                (interpolative decomposition). See supplemental S6 of 
-                https://arxiv.org/abs/2310.15069"
-            default = "hc"
+        "--linkage"
+            help = "Linkage function to use for defining group membership. It 
+                defines how the distances between features are aggregated into
+                the distances between groups. Valid choices include `average` 
+                (default), `single`, `complete`, `ward`, and `ward_presquared`.
+                Note if `force_contiguous=true`, `linkage` must be `:single`"
+            default = "average"
             arg_type = String
+        "--force_contiguous"
+            help = "whether to force groups to be contiguous (default `false`).
+                Note if `force_contiguous=true`, `linkage` must be `:single`)"
+            default = false
+            arg_type = Bool
         "--group_cor_cutoff"
             help = "correlation cutoff value for defining groups (default 
                 `0.5`). Value should be between 0 and 1, where larger values
@@ -324,12 +331,13 @@ function parse_solveblock_commandline(parseargs::Bool)
     min_maf = parsed_args["min_maf"]
     min_hwe = parsed_args["min_hwe"]
     method = parsed_args["method"]
-    group_def = parsed_args["group_def"]
+    linkage = parsed_args["linkage"]
+    force_contiguous = parsed_args["force_contiguous"]
     group_cor_cutoff = parsed_args["group_cor_cutoff"]
     group_rep_cutoff = parsed_args["group_rep_cutoff"]
     verbose = parsed_args["verbose"]
 
     return vcffile, chr, start_bp, end_bp, outdir, 
-        hg_build, tol, min_maf, min_hwe, method, group_def, group_cor_cutoff, 
-        group_rep_cutoff, verbose
+        hg_build, tol, min_maf, min_hwe, method, linkage, force_contiguous, 
+        group_cor_cutoff, group_rep_cutoff, verbose
 end

--- a/src/app.jl
+++ b/src/app.jl
@@ -224,17 +224,17 @@ function parse_solveblock_commandline(parseargs::Bool)
     s = ArgParseSettings()
     @add_arg_table! s begin
         "--vcffile"
-            help = "A VCF file storing individual level genotypes. Must end in
-                `.vcf` or `.vcf.gz`. The ALT field for each record must be
-                unique, i.e. multiallelic records must be split first. Missing
-                genotypes will be imputed by column mean."
+            help = "A VCF file storing individual level genotypes. Must end in " *
+                "`.vcf` or `.vcf.gz`. The ALT field for each record must be " *
+                "unique, i.e. multiallelic records must be split first. Missing " *
+                "genotypes will be imputed by column mean."
             required = true
             arg_type = String
         "--chr"
-            help = "Target chromosome. This MUST be an integer and it must match 
-                the `CHROM` field in your VCF file. Thus, if your VCF file has
-                CHROM field like `chr1`, `CHR1`, or `CHROM1` etc, each record
-                must be renamed into `1`."
+            help = "Target chromosome. This MUST be an integer and it must match " *
+                "the `CHROM` field in your VCF file. Thus, if your VCF file has " *
+                "CHROM field like `chr1`, `CHR1`, or `CHROM1` etc, each record " *
+                "must be renamed into `1`."
             required = true
             arg_type = Int
         "--start_bp"
@@ -250,54 +250,54 @@ function parse_solveblock_commandline(parseargs::Bool)
             required = true
             arg_type = String
         "--genome-build"
-            help = "human genome build for the VCF file, must be 19 (hg19) or
-                38 (hg38)"
+            help = "human genome build for the VCF file, must be 19 (hg19) or " *
+                "38 (hg38)"
             required = true
             arg_type = Int
         "--tol"
-            help = "Convergence tolerlance for coordinate descent algorithm 
-                    (default `0.0001`)"
+            help = "Convergence tolerlance for coordinate descent algorithm " *
+                "(default `0.0001`)"
             default = 0.0001
             arg_type = Float64
         "--min_maf"
-            help = "Minimum minor allele frequency for a variable to be
-                considered (default `0.01`)"
+            help = "Minimum minor allele frequency for a variable to be " *
+                "considered (default `0.01`)"
             default = 0.01
             arg_type = Float64
         "--min_hwe"
-            help = "Cutoff for hardy-weinburg equilibrium p-values. Only SNPs with 
-                p-value > `min_hwe` will be included (default `0.0`)"
+            help = "Cutoff for hardy-weinburg equilibrium p-values. Only SNPs with " *
+                "p-value > `min_hwe` will be included (default `0.0`)"
             default = 0.0
             arg_type = Float64
         "--method"
-            help = "group knockoff optimization algorithm, choices include `maxent`
-                (defualt), `mvr`, `sdp`, or `equi`. See sec 2 of 
-                https://arxiv.org/abs/2310.15069"
+            help = "group knockoff optimization algorithm, choices include `maxent` " *
+                "(defualt), `mvr`, `sdp`, or `equi`. See sec 2 of " *
+                "https://arxiv.org/abs/2310.15069"
             default = "maxent"
             arg_type = String
         "--linkage"
-            help = "Linkage function to use for defining group membership. It 
-                defines how the distances between features are aggregated into
-                the distances between groups. Valid choices include `average` 
-                (default), `single`, `complete`, `ward`, and `ward_presquared`.
-                Note if `force_contiguous=true`, `linkage` must be `:single`"
+            help = "Linkage function to use for defining group membership. It " *
+                "defines how the distances between features are aggregated into " *
+                "the distances between groups. Valid choices include `average` " *
+                "(default), `single`, `complete`, `ward`, and `ward_presquared`. " *
+                "Note if `force_contiguous=true`, `linkage` must be `:single`"
             default = "average"
             arg_type = String
         "--force_contiguous"
-            help = "whether to force groups to be contiguous (default `false`).
-                Note if `force_contiguous=true`, `linkage` must be `:single`)"
+            help = "whether to force groups to be contiguous (default `false`). " *
+                "Note if `force_contiguous=true`, `linkage` must be `:single`)"
             default = false
             arg_type = Bool
         "--group_cor_cutoff"
-            help = "correlation cutoff value for defining groups (default 
-                `0.5`). Value should be between 0 and 1, where larger values
-                correspond to larger groups."
+            help = "correlation cutoff value for defining groups (default " *
+                "`0.5`). Value should be between 0 and 1, where larger values " *
+                "correspond to larger groups."
             arg_type = Float64
             default = 0.5
         "--group_rep_cutoff"
-            help = "cutoff value for selecting group-representatives (default
-                `0.5`). Value should be between 0 and 1, where larger values
-                correspond to more representatives per group. "
+            help = "cutoff value for selecting group-representatives (default " *
+                "`0.5`). Value should be between 0 and 1, where larger values " *
+                "correspond to more representatives per group. "
             arg_type = Float64
             default = 0.5
         "--verbose"

--- a/src/app.jl
+++ b/src/app.jl
@@ -253,7 +253,7 @@ function parse_solveblock_commandline(parseargs::Bool)
             help = "human genome build for the VCF file, must be 19 (hg19) or
                 38 (hg38)"
             required = true
-            arg_type = String
+            arg_type = Int
         "--tol"
             help = "Convergence tolerlance for coordinate descent algorithm 
                     (default `0.0001`)"

--- a/src/app.jl
+++ b/src/app.jl
@@ -152,7 +152,8 @@ function parse_ghostknockoffgwas_commandline(parseargs::Bool)
             ["--zfile","testdir","--LD-files","testdir2",
             "--N","1","--genome-build","38","--out","testdir3",
             "--CHR","1","--POS","2","--REF","3","--ALT","4","--Z","5",
-            "--seed","2024","--verbose","true"], s
+            "--seed","2024","--verbose","true","--random-shuffle","true",
+            "--skip-shrinkage-check","false"], s
         )
         _useless = parse_args(["--help"], s)
         return nothing
@@ -230,10 +231,12 @@ function parse_solveblock_commandline(parseargs::Bool)
             required = true
             arg_type = String
         "--chr"
-            help = "Target chromosome. This must match the `CHROM` field in 
-                the VCF file. "
+            help = "Target chromosome. This MUST be an integer and it must match 
+                the `CHROM` field in your VCF file. Thus, if your VCF file has
+                CHROM field like `chr1`, `CHR1`, or `CHROM1` etc, each record
+                must be renamed into `1`."
             required = true
-            arg_type = String
+            arg_type = Int
         "--start_bp"
             help = "starting basepair (position)"
             required = true
@@ -295,8 +298,8 @@ function parse_solveblock_commandline(parseargs::Bool)
             help = "cutoff value for selecting group-representatives (default
                 `0.5`). Value should be between 0 and 1, where larger values
                 correspond to more representatives per group. "
-            arg_type = Bool
-            default = true
+            arg_type = Float64
+            default = 0.5
         "--verbose"
             help = "Whether to print intermediate messages"
             arg_type = Bool
@@ -313,8 +316,9 @@ function parse_solveblock_commandline(parseargs::Bool)
             ["--vcffile","testfile","--chr","1","--start_bp","1","--end_bp","2",
             "--outdir","testdir","--genome-build","19","--tol","0.0001",
             "--min_maf","0.01","--min_hwe","0.01","--method","maxent",
-            "--group_def","hc","--group_cor_cutoff","0.5",
-            "group_rep_cutoff","0.5", "--verbose","true"], s
+            "--linkage","average","--force_contiguous","false",
+            "--group_cor_cutoff","0.5","--group_rep_cutoff","0.5",
+            "--verbose","true"], s
         )
         _useless = parse_args(["--help"], s)
         return nothing

--- a/src/app.jl
+++ b/src/app.jl
@@ -1,10 +1,11 @@
-# main function that PackageCompiler will build against
+# this becomes the GhostKnockoffGWAS executable
 function julia_main()::Cint
     try
         # read command line arguments
         zfile, LD_files, N, hg_build, outfile, outdir, chr_col, pos_col, 
             ref_col, alt_col, z_col, seed, verbose,
-            random_shuffle, skip_shrinkage_check = parse_commandline(true)
+            random_shuffle, skip_shrinkage_check = 
+            parse_ghostknockoffgwas_commandline(true)
 
         println("\n\nWelcome to GhostKnockoffGWAS analysis!")
         println("You have specified the following options:")
@@ -60,7 +61,7 @@ function julia_main()::Cint
     return 0
 end
 
-function parse_commandline(parseargs::Bool)
+function parse_ghostknockoffgwas_commandline(parseargs::Bool)
     s = ArgParseSettings()
     @add_arg_table! s begin
         "--zfile"
@@ -178,4 +179,157 @@ function parse_commandline(parseargs::Bool)
     return zfile, LD_files, N, hg_build, outfile, outdir, 
         chr_col, pos_col, ref_col, alt_col, z_col, seed, verbose, 
         random_shuffle, skip_shrinkage_check
+end
+
+function julia_solveblock()::Cint
+    try
+        # read command line arguments
+        vcffile, chr, start_bp, end_bp, outdir, 
+            hg_build, tol, min_maf, min_hwe, method, group_def, group_cor_cutoff, 
+            group_rep_cutoff, verbose = parse_solveblock_commandline(true)
+
+        println("\n\nWelcome to the `solve_block` module of GhostKnockoffGWAS!")
+        println("You have specified the following options:")
+        println("vcffile          = ", abspath(vcffile))
+        println("chr              = ", chr)
+        println("start_bp         = ", start_bp)
+        println("end_bp           = ", end_bp)
+        println("outdir           = ", abspath(outdir))
+        println("hg_build         = ", hg_build)
+        println("tol              = ", tol)
+        println("min_maf          = ", min_maf)
+        println("min_hwe          = ", min_hwe)
+        println("method           = ", method)
+        println("group_def        = ", group_def)
+        println("group_cor_cutoff = ", group_cor_cutoff)
+        println("group_rep_cutoff = ", group_rep_cutoff)
+        println("verbose          = ", verbose)
+        println("\n")
+
+        solve_blocks(vcffile, chr, start_bp, end_bp, outdir, 
+            hg_build, tol=tol, min_maf=min_maf, min_hwe=min_hwe, 
+            method=method, group_def=group_def, 
+            group_cor_cutoff=group_cor_cutoff, 
+            group_rep_cutoff=group_rep_cutoff, verbose=verbose)
+    catch
+        Base.invokelatest(Base.display_error, Base.catch_stack())
+        return 1
+    end
+    return 0
+end
+
+function parse_solveblock_commandline(parseargs::Bool)
+    s = ArgParseSettings()
+    @add_arg_table! s begin
+        "--vcffile"
+            help = "A VCF file storing individual level genotypes. Must end in
+                `.vcf` or `.vcf.gz`. The ALT field for each record must be
+                unique, i.e. multiallelic records must be split first. Missing
+                genotypes will be imputed by column mean."
+            required = true
+            arg_type = String
+        "--chr"
+            help = "Target chromosome. This must match the `CHROM` field in 
+                the VCF file. "
+            required = true
+            arg_type = String
+        "--start_bp"
+            help = "starting basepair (position)"
+            required = true
+            arg_type = Int
+        "--end_bp"
+            help = "ending basepair (position)"
+            arg_type = Int
+            required = true
+        "--outdir"
+            help = "Directory that the output will be stored in (must exist)"
+            required = true
+            arg_type = String
+        "--genome-build"
+            help = "human genome build for the VCF file, must be 19 (hg19) or
+                38 (hg38)"
+            required = true
+            arg_type = String
+        "--tol"
+            help = "Convergence tolerlance for coordinate descent algorithm 
+                    (default `0.0001`)"
+            default = 0.0001
+            arg_type = Float64
+        "--min_maf"
+            help = "Minimum minor allele frequency for a variable to be
+                considered (default `0.01`)"
+            default = 0.01
+            arg_type = Float64
+        "--min_hwe"
+            help = "Cutoff for hardy-weinburg equilibrium p-values. Only SNPs with 
+                p-value > `min_hwe` will be included (default `0.0`)"
+            default = 0.0
+            arg_type = Float64
+        "--method"
+            help = "group knockoff optimization algorithm, choices include `maxent`
+                (defualt), `mvr`, `sdp`, or `equi`. See sec 2 of 
+                https://arxiv.org/abs/2310.15069"
+            default = "maxent"
+            arg_type = String
+        "--group_def"
+            help = "method for constructing groups, choices include `hc`
+                (default, average-linkage hierarchical clustering) or `id`
+                (interpolative decomposition). See supplemental S6 of 
+                https://arxiv.org/abs/2310.15069"
+            default = "hc"
+            arg_type = String
+        "--group_cor_cutoff"
+            help = "correlation cutoff value for defining groups (default 
+                `0.5`). Value should be between 0 and 1, where larger values
+                correspond to larger groups."
+            arg_type = Float64
+            default = 0.5
+        "--group_rep_cutoff"
+            help = "cutoff value for selecting group-representatives (default
+                `0.5`). Value should be between 0 and 1, where larger values
+                correspond to more representatives per group. "
+            arg_type = Bool
+            default = true
+        "--verbose"
+            help = "Whether to print intermediate messages"
+            arg_type = Bool
+            default = true
+    end
+
+    # This is for code pre-compilation, enabling fast printing of "help statement".
+    # It runs the parser once when the module is loaded
+    # so that Julia can compile everything including functions that are defined in
+    # other modules. Of course, we need to make sure that the arguments are valid or
+    # the module will fail to load
+    if !parseargs
+        _useless = parse_args(
+            ["--vcffile","testfile","--chr","1","--start_bp","1","--end_bp","2",
+            "--outdir","testdir","--genome-build","19","--tol","0.0001",
+            "--min_maf","0.01","--min_hwe","0.01","--method","maxent",
+            "--group_def","hc","--group_cor_cutoff","0.5",
+            "group_rep_cutoff","0.5", "--verbose","true"], s
+        )
+        _useless = parse_args(["--help"], s)
+        return nothing
+    end
+
+    parsed_args = parse_args(s)
+    vcffile = parsed_args["vcffile"]
+    chr = parsed_args["chr"]
+    start_bp = parsed_args["start_bp"]
+    end_bp = parsed_args["end_bp"]
+    outdir = parsed_args["outdir"]
+    hg_build = parsed_args["genome-build"]
+    tol = parsed_args["tol"]
+    min_maf = parsed_args["min_maf"]
+    min_hwe = parsed_args["min_hwe"]
+    method = parsed_args["method"]
+    group_def = parsed_args["group_def"]
+    group_cor_cutoff = parsed_args["group_cor_cutoff"]
+    group_rep_cutoff = parsed_args["group_rep_cutoff"]
+    verbose = parsed_args["verbose"]
+
+    return vcffile, chr, start_bp, end_bp, outdir, 
+        hg_build, tol, min_maf, min_hwe, method, group_def, group_cor_cutoff, 
+        group_rep_cutoff, verbose
 end

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -51,7 +51,7 @@ function get_block(
     )
     reader = VCF.Reader(openvcf(vcffile, "r"))
     T = Float64
-    n = nsamples(vcffile)
+    n = VCFTools.nsamples(vcffile)
     nsnps = 0
     X = ElasticArray{T}(undef, n, 0)
     df = DataFrame("rsid"=>String[], "AF"=>T[], "chr"=>String[], "pos"=> Int[], 

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -8,7 +8,9 @@ function estimate_sigma(X::AbstractMatrix)
 end
 
 """
-    get_block(vcffile, )
+    get_block(vcffile::String, chr::String, start_bp::Int, end_bp::Int;
+        [min_maf::Float64=0.01], [min_hwe::Float64=0.0], 
+        [snps_to_keep::Union{AbstractVector{Int}, Nothing}=nothing])
 
 Imports genotype data of a VCF file from pos `start_bp` to `end_bp` as 
 double precision numeric matrix.
@@ -105,21 +107,6 @@ function get_block(
 
     return Matrix(X), df
 end
-# using VCFTools, VariantCallFormat, ElasticArrays, DataFrames
-# vcffile = "/oak/stanford/groups/zihuai/paisa/chr1.vcf.gz"
-# chr = "1"
-# min_maf = 0.0
-# min_hwe = 0.0
-# start_bp = 58814 # first 10 records
-# end_bp = 801536
-# @time X, df = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
-# 0.012035 seconds (46.78 k allocations: 13.440 MiB)
-
-# chr = "1"
-# start_bp = 249208612 # last 10 records
-# end_bp = 249222527
-# @time X, df = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
-# 44.146655 seconds (196.81 M allocations: 53.676 GiB, 2.20% gc time)
 
 function validate(record, alt_i)
     if VariantCallFormat.findgenokey(record, "GT") === nothing
@@ -230,23 +217,6 @@ function solve_blocks(
     group_rep_cutoff::Float64=0.5,
     verbose=true
     )
-    # using VCFTools, VariantCallFormat, ElasticArrays, DataFrames, Statistics, LinearAlgebra, Knockoffs
-    # vcffile = "/oak/stanford/groups/zihuai/paisa/chr1.vcf.gz"
-    # chr = "1"
-    # min_maf = 0.01
-    # min_hwe = 1e-8
-    # start_bp = 58814 # first 500 records
-    # end_bp = 2338569
-    # snps_to_keep = nothing
-    # hg_build = 19
-    # group_def = "hc"
-    # group_cor_cutoff = 0.5
-    # group_rep_cutoff = 0.5
-    # method = "maxent"
-    # m = 5
-    # tol = 0.0001
-    # verbose = true
-
     isdir(outdir) || error("output directory $outdir does not exist!")
     group_def ∈ ["hc", "id"] || error("group_def should be \"hc\" or \"id\"")
     method = Symbol(method)

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -10,16 +10,24 @@ double precision numeric matrix.
 
 # Inputs
 + `vcffile`: A VCF file storing individual level genotypes. Must end in `.vcf` 
-    or `.vcf.gz`. The CHROM field for all SNPs must equal to the input `chr` 
-    for computational reasons. Finally, the ALT field for each record must be 
-    unique, i.e. multiallelic records must be split first. 
-+ `chr`: 
+    or `.vcf.gz`. The ALT field for each record must be unique, i.e. 
+    multiallelic records must be split first. Missing genotypes will be imputed.
++ `chr`: Target chromosome. This must match the `CHROM` field in the VCF file. 
++ `start_bp`: starting basepair (position)
++ `end_bp`: ending basepair (position)
 
 # Optional inputs
-+ 
++ `min_maf`: minimum minor allele frequency for a SNP to be imported (default `0.01`)
++ `min_hwe`: minimum HWE p-value for a SNP to be imported (default `0.0`)
 
 # output
-+ ``
++ `X`: Double precision matrix containing genotypes between `start_bp` and 
+    `end_bp`. All entries are {0, 1, 2} except for missing entries which is 
+    imputed with column mean.
++ `chrs`: Chromosome for each column of `X`
++ `poss`: Basepair position for each column of `X`
++ `ref`: Reference allele for each column of `X`
++ `alt`: Alt allele for each column of `X`
 """
 function get_block(
     vcffile::String, 

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -99,6 +99,7 @@ function get_block(
         push!(df, [join(VCF.id(record), ','), alt_freq, chr_i, pos_i, 
                   VCF.ref(record), alt_i[1]])
     end
+    close(reader)
 
     if !isnothing(snps_to_keep) 
         idx = filter!(!isnothing, indexin(snps_to_keep, df[!, "pos"]))

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -280,7 +280,7 @@ function solve_blocks(
     dir = joinpath(outdir, "chr$chr")
     isdir(dir) || mkpath(dir)
     JLD2.save(
-        joinpath(dir, "LD_start$(start_pos)_end$(end_pos).h5"), 
+        joinpath(dir, "LD_start$(start_bp)_end$(end_bp).h5"), 
         Dict(
             "S" => S,
             "D" => D,
@@ -292,8 +292,8 @@ function solve_blocks(
             "Sigma_reps_inv" => inv(Sigma[group_reps, group_reps])
         )
     )
-    CSV.write(joinpath(dir, "Info_start$(start_pos)_end$(end_pos).csv"), data_info)
-    open(joinpath(dir, "summary_start$(start_pos)_end$(end_pos)"), "w") do io
+    CSV.write(joinpath(dir, "Info_start$(start_bp)_end$(end_bp).csv"), data_info)
+    open(joinpath(dir, "summary_start$(start_bp)_end$(end_bp)"), "w") do io
         println(io, "chr,$chr")
         println(io, "start_bp,$start_bp")
         println(io, "end_bp,$end_bp")

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -1,0 +1,112 @@
+function estimate_sigma(X::AbstractMatrix)
+    return cor(X)
+end
+
+"""
+    get_block(vcffile, )
+
+Imports genotype data of a VCF file from pos `start_bp` to `end_bp` as 
+double precision numeric matrix.
+
+# Inputs
++ `vcffile`: A VCF file storing individual level genotypes. Must end in `.vcf` 
+    or `.vcf.gz`. The CHROM field for all SNPs must equal to the input `chr` 
+    for computational reasons. Finally, the ALT field for each record must be 
+    unique, i.e. multiallelic records must be split first. 
++ `chr`: 
+
+# Optional inputs
++ 
+
+# output
++ ``
+"""
+function get_block(
+    vcffile::String, 
+    chr::Union{String, Int}, 
+    start_bp::Union{String, Int}, 
+    end_bp::Union{String, Int};
+    min_maf::Float64=0.01,
+    min_hwe::Float64=0.0
+    )
+    chr = string(chr)
+    start_bp = Int(start_bp)
+    end_bp = Int(end_bp)
+
+    reader = VCF.Reader(openvcf(vcffile, "r"))
+    T = Float64
+    n = nsamples(vcffile)
+    nsnps = 0
+    X = ElasticArray{T}(undef, n, 0)
+    chrs, poss, refs, alts = String[], Int[], String[], String[]
+    model = :additive # additive genetic model
+
+    for record in reader
+        # check chr
+        chr_i = VCF.chrom(record)
+        chr_i > chr && break
+
+        # check position
+        pos_i = VCF.pos(record)
+        pos_i < start_bp && continue
+        pos_i > end_bp && break
+
+        # check SNP is usable
+        alt_i = VCF.alt(record)
+        validate(record, alt_i)
+        _, _, _, _, _, alt_freq, _, _, _, maf, hwepval = gtstats(record, nothing)
+        maf < min_maf && continue
+        hwepval < min_hwe && continue
+        gtkey = VariantCallFormat.findgenokey(record, "GT")
+
+        # add column to X
+        nsnps += 1
+        resize!(X, n, nsnps)
+        for i in 1:n
+            geno = record.genotype[i]
+            if gtkey > lastindex(geno) || geno_ismissing(record, geno[gtkey])
+                # Missing: fill with MAF
+                X[i, end] = 2alt_freq
+            else # not missing
+                # "0" (REF) => 0x30, "1" (ALT) => 0x31
+                a1 = record.data[geno[gtkey][1]] == 0x31
+                a2 = record.data[geno[gtkey][3]] == 0x31
+                X[i, end] = convert_gt(T, (a1, a2), model)
+            end
+        end
+
+        # save record info
+        push!(chrs, chr_i)
+        push!(poss, pos_i)
+        push!(refs, VCF.ref(record))
+        push!(alts, alt_i[1])
+    end
+
+    return Matrix(X), chrs, poss, refs, alts
+end
+# using VCFTools, VariantCallFormat, ElasticArrays
+# vcffile = "/oak/stanford/groups/zihuai/paisa/chr1.vcf.gz"
+# chr = 1 
+# min_maf = 0.0
+# min_hwe = 0.0
+# start_bp = 58814 # first 10 records
+# end_bp = 801536
+# @time X, chr, pos, ref, alt = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
+# 0.014761 seconds (60.13 k allocations: 18.505 MiB, 9.10% gc time)
+
+# chr = 1 
+# start_bp = 249208612 # last 10 records
+# end_bp = 249222527
+# @time X, chr, pos, ref, alt = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
+# 54.847166 seconds (263.11 M allocations: 78.248 GiB, 2.47% gc time)
+
+
+function validate(record, alt_i)
+    if VariantCallFormat.findgenokey(record, "GT") === nothing
+        error("chr $chr_i at pos $pos_i has no GT field!")
+    end
+    if length(alt_i) > 1
+        error("Detected multiallelic marker at chr $chr_i pos $pos_i. " * 
+              "Please split multiallelic markers first." )
+    end
+end

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -279,21 +279,18 @@ function solve_blocks(
     # save main result in .h5 format and summary information in .csv
     dir = joinpath(outdir, "chr$chr")
     isdir(dir) || mkpath(dir)
-    JLD2.save(
-        joinpath(dir, "LD_start$(start_bp)_end$(end_bp).h5"), 
-        Dict(
-            "S" => S,
-            "D" => D,
-            "Sigma" => Sigma,
-            "SigmaInv" => inv(Sigma),
-            "groups" => groups,
-            "group_reps" => group_reps,
-            "Sigma_reps" => Sigma[group_reps, group_reps],
-            "Sigma_reps_inv" => inv(Sigma[group_reps, group_reps])
-        )
-    )
+    h5open(joinpath(dir, "LD_start$(start_bp)_end$(end_bp).h5"), "w") do file
+        write(file, "S", S)
+        write(file, "D", D)
+        write(file, "Sigma", Sigma)
+        write(file, "SigmaInv", inv(Sigma))
+        write(file, "groups", groups)
+        write(file, "group_reps", group_reps)
+        write(file, "Sigma_reps", Sigma[group_reps, group_reps])
+        write(file, "Sigma_reps_inv", inv(Sigma[group_reps, group_reps]))
+    end
     CSV.write(joinpath(dir, "Info_start$(start_bp)_end$(end_bp).csv"), data_info)
-    open(joinpath(dir, "summary_start$(start_bp)_end$(end_bp)"), "w") do io
+    open(joinpath(dir, "summary_start$(start_bp)_end$(end_bp).csv"), "w") do io
         println(io, "chr,$chr")
         println(io, "start_bp,$start_bp")
         println(io, "end_bp,$end_bp")
@@ -311,6 +308,7 @@ function solve_blocks(
         println("Time to read VCF file: $import_time")
         println("Time to define groups: $def_group_time")
         println("Time to perform group knockoff optimization: $solve_S_time")
+        println("Done!")
     end
 
     return nothing

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -75,7 +75,7 @@ function get_block(
         alt_i = VCF.alt(record)
         validate(record, alt_i)
         _, _, _, _, _, alt_freq, _, _, _, maf, hwepval = gtstats(record, nothing)
-        maf < min_maf && continue
+        (isnan(maf) || maf < min_maf) && continue
         hwepval < min_hwe && continue
         gtkey = VariantCallFormat.findgenokey(record, "GT")
 

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -31,25 +31,25 @@ double precision numeric matrix.
 """
 function get_block(
     vcffile::String, 
-    chr::Union{String, Int}, 
-    start_bp::Union{String, Int}, 
-    end_bp::Union{String, Int};
+    chr::String, 
+    start_bp::Int, 
+    end_bp::Int;
     min_maf::Float64=0.01,
     min_hwe::Float64=0.0
     )
-    chr = string(chr)
-    start_bp = Int(start_bp)
-    end_bp = Int(end_bp)
-
     reader = VCF.Reader(openvcf(vcffile, "r"))
     T = Float64
     n = nsamples(vcffile)
     nsnps = 0
     X = ElasticArray{T}(undef, n, 0)
-    chrs, poss, refs, alts = String[], Int[], String[], String[]
+    df = DataFrame("rsid"=>String[], "AF"=>T[], "chr"=>String[], "pos"=> Int[], 
+                   "ref"=> String[], "alt"=>String[])
     model = :additive # additive genetic model
 
-    for record in reader
+    record = VCF.Record()
+    while !eof(reader)
+        read!(reader, record)
+
         # check chr
         chr_i = VCF.chrom(record)
         chr_i > chr && break
@@ -84,30 +84,27 @@ function get_block(
         end
 
         # save record info
-        push!(chrs, chr_i)
-        push!(poss, pos_i)
-        push!(refs, VCF.ref(record))
-        push!(alts, alt_i[1])
+        push!(df, [join(VCF.id(record), ','), alt_freq, chr_i, pos_i, 
+                  VCF.ref(record), alt_i[1]])
     end
 
-    return Matrix(X), chrs, poss, refs, alts
+    return Matrix(X), df
 end
-# using VCFTools, VariantCallFormat, ElasticArrays
+# using VCFTools, VariantCallFormat, ElasticArrays, DataFrames
 # vcffile = "/oak/stanford/groups/zihuai/paisa/chr1.vcf.gz"
-# chr = 1 
+# chr = "1"
 # min_maf = 0.0
 # min_hwe = 0.0
 # start_bp = 58814 # first 10 records
 # end_bp = 801536
-# @time X, chr, pos, ref, alt = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
-# 0.014761 seconds (60.13 k allocations: 18.505 MiB, 9.10% gc time)
+# @time X, df = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
+# 0.012035 seconds (46.78 k allocations: 13.440 MiB)
 
-# chr = 1 
+# chr = "1"
 # start_bp = 249208612 # last 10 records
 # end_bp = 249222527
-# @time X, chr, pos, ref, alt = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
-# 54.847166 seconds (263.11 M allocations: 78.248 GiB, 2.47% gc time)
-
+# @time X, df = get_block(vcffile, chr, start_bp, end_bp, min_maf=min_maf, min_hwe=min_hwe)
+# 44.146655 seconds (196.81 M allocations: 53.676 GiB, 2.20% gc time)
 
 function validate(record, alt_i)
     if VariantCallFormat.findgenokey(record, "GT") === nothing

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -134,7 +134,7 @@ function rearrange_snps!(groups, group_reps, Sigma, Sigma_info)
 end
 
 """
-    solve_blocks(vcffile::String, chr::String, start_bp::Int, end_bp::Int, 
+    solve_blocks(vcffile::String, chr::Int, start_bp::Int, end_bp::Int, 
         outdir::String, hg_build::Int; [m=5], [tol=0.0001], [min_maf=0.01], 
         [min_hwe=0.0], [force_block_diag=true], 
         [method::String = "maxent"], [group_def::String="hc"], 
@@ -156,7 +156,9 @@ function.
     or `.vcf.gz`. The ALT field for each record must be unique, i.e. 
     multiallelic records must be split first. Missing genotypes will be imputed
     by column mean. 
-+ `chr`: Target chromosome. This must match the `CHROM` field in the VCF file. 
++ `chr`: Target chromosome. This MUST be an integer and it must match the `CHROM`
+    field in your VCF file. Thus, if your VCF file has CHROM field like `chr1`, 
+    `CHR1`, or `CHROM1` etc, each record must be renamed into `1`. 
 + `start_bp`: starting basepair (position)
 + `end_bp`: ending basepair (position)
 + `outdir`: Directory that the output will be stored in (must exist)
@@ -219,7 +221,7 @@ Calling `solve_blocks` will create 3 files in the directory `outdir/chr`:
 """
 function solve_blocks(
     vcffile::String,
-    chr::String,
+    chr::Int,
     start_bp::Int, 
     end_bp::Int, 
     outdir::String,
@@ -249,7 +251,7 @@ function solve_blocks(
 
     # import VCF data and estimate Sigma
     import_time = @elapsed begin
-        X, data_info = get_block(vcffile, chr, start_bp, end_bp, 
+        X, data_info = get_block(vcffile, string(chr), start_bp, end_bp, 
             min_maf=min_maf, min_hwe=min_hwe, snps_to_keep=snps_to_keep)
         Sigma = Symmetric(estimate_sigma(X))
         rename!(data_info, "pos" => "pos_hg$hg_build") # associate pos with hg_build

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -1,10 +1,16 @@
-function estimate_sigma(X::AbstractMatrix)
+function estimate_sigma(X::AbstractMatrix; min_eigval=1e-5)
     n, p = size(X)
     if n > p
-        return cor(X)
+        Sigma = cor(X)
     else
         error("p > n case not handled yet!")
     end
+    # ensure Sigma is PSD
+    evals, evecs = eigen(Sigma)
+    evals[findall(x -> x < min_eigval, evals)] .= min_eigval
+    Sigma = evecs * Diagonal(evals) * evecs'
+    Statistics.cov2cor!(Sigma, sqrt.(diag(Sigma))) # scale to correlation matrix
+    return Sigma
 end
 
 """

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,3 +1,4 @@
 # fast GhostKnockoffGwAS --help
 using GhostKnockoffGWAS
-GhostKnockoffGWAS.parse_commandline(false)
+GhostKnockoffGWAS.parse_solveblock_commandline(false)
+GhostKnockoffGWAS.parse_ghostknockoffgwas_commandline(false)


### PR DESCRIPTION
This PR adds the `solve_blocks()` function. A compiled executable will be provided and new version of `GhostKnockoffGWAS` tagged once we tested it more extensively. 

This will allow users to build custom LD files from individual-level data stored in VCF files. Currently, this is the only way for users to use LD files not prepared by us, the developers of `GhostKnockoffGWAS`. 