### PR TITLE
Improve LD shrinkage efficiency

### DIFF
--- a/src/ghostbasil_parallel.jl
+++ b/src/ghostbasil_parallel.jl
@@ -181,14 +181,16 @@ function ghostknockoffgwas(
 
                 # shrinkage for consistency
                 t21 += @elapsed begin
-                    # γ = find_optimal_shrinkage(Σi, zi)
-                    # γ_mean += γ
-                    shared_rep_pos = intersect(shared_pos, rep_pos)
-                    Σi_idx = filter!(!isnothing, indexin(shared_rep_pos, rep_pos))
-                    zi_idx = filter!(!isnothing, indexin(shared_rep_pos, shared_pos))
-                    Σi_rep = read(h5reader, "Sigma_reps")[Σi_idx, Σi_idx]
-                    zi_rep = zi[zi_idx]
-                    γ = find_optimal_shrinkage(Σi_rep, zi_rep)
+                    if length(zi) > 1000 # use reps to compute shrinkage
+                        shared_rep_pos = intersect(shared_pos, rep_pos)
+                        Σi_idx = filter!(!isnothing, indexin(shared_rep_pos, rep_pos))
+                        zi_idx = filter!(!isnothing, indexin(shared_rep_pos, shared_pos))
+                        Σi_rep = read(h5reader, "Sigma_reps")[Σi_idx, Σi_idx]
+                        zi_rep = zi[zi_idx]
+                        γ = find_optimal_shrinkage(Σi_rep, zi_rep)
+                    else
+                        γ = find_optimal_shrinkage(Σi, zi)
+                    end
                     γ_mean += γ
                     if LD_shrinkage
                         Σi = (1 - γ)*Σi + γ*I

--- a/src/make_hdf5.jl
+++ b/src/make_hdf5.jl
@@ -20,7 +20,7 @@ end
 
 
 """
-    get_VCF_block(file::String, chr::Int, start_bp::Int, end_bp::Int;
+    get_block(file::String, chr::Int, start_bp::Int, end_bp::Int;
         [min_maf::Float64=0.01], [min_hwe::Float64=0.0], 
         [snps_to_keep::Union{AbstractVector{Int}, Nothing}=nothing])
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -51,6 +51,8 @@ function neg_mvn_logl_under_null(evals, evecs, z::AbstractVector, γ::Number)
     return sum(log.(evals_scaled)) + dot(z_scaled, Diagonal(1 ./ evals_scaled), z_scaled)
 end
 function find_optimal_shrinkage(Σ::AbstractMatrix, z::AbstractVector)
+    size(Σ, 1) == size(Σ, 2) == length(z) || 
+        error("find_optimal_shrinkage: Dimension mismatch")
     evals, evecs = eigen(Symmetric(Σ))
     opt = optimize(
         γ -> neg_mvn_logl_under_null(evals, evecs, z, γ), 


### PR DESCRIPTION
## Motivation

When a LD matrix is too large (e.g. >5000 variables), the function `find_optimal_shrinkage` becomes too slow. 

## Proposal

Rather than computing shrinkage on the entire correlation matrix, we can do so on just the group representative variables, since these variables are primary drivers for the dependencies across groups. This often reduce the LD matrix size by a factor of 10. 

## Potential issue

Often there are few representatives in a block (e.g. < 10). This can lead to large shrinkage values (e.g. >0.5) even though the LD matrix matches the Z-score exactly. 

## this PR

Now we compute shrinkage on the original matrix if the size is manageable (<1000 variables), otherwise we change to computing shrinkage value on the representatives. 

## Before merging 

To check this approach is reasonable, we should re-run the Alzheimer's disease study to see if the shrinkage value is comparable to previously (which I think we around 0.01 to 0.02).