### PR TITLE
Add ld_split function

### DIFF
--- a/docs/src/man/solveblocks.ipynb
+++ b/docs/src/man/solveblocks.ipynb
@@ -94,8 +94,28 @@
    "source": [
     "## Determining `start_bp` and `end_bp`\n",
     "\n",
-    "+ In our papers, we defined each start and end position by adapting the [quasi-independent regions of ldetect](https://bitbucket.org/nygcresearch/ldetect-data/src/master/). \n",
-    "+ Given individual level data, one can compute approximately independent LD blocks directly, see [reference](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8696101/) and [R software](https://privefl.github.io/bigsnpr/reference/snp_ldsplit.html)."
+    "There are 2 options:\n",
+    "\n",
+    "1. One can defined each start and end position by leveraging existing quasi-independent regions for your target sample. For example, we previously used the European blocks of [ldetect](https://bitbucket.org/nygcresearch/ldetect-data/src/master/). \n",
+    "2. Given individual level data, one can compute approximately independent LD blocks directly, see [reference](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8696101/) and [R software](https://privefl.github.io/bigsnpr/reference/snp_ldsplit.html).\n",
+    "\n",
+    "For option 2, we provide an [R script](https://github.com/biona001/GhostKnockoffGWAS/blob/main/src/ld_split.R) which can be ran in the terminal (this requires the `R` packages `bigsnpr` and `dplyr`). Usage:\n",
+    "\n",
+    "```R\n",
+    "$ Rscript --vanilla ld_split.R arg1 arg2 arg3 arg4 arg5 arg6\n",
+    "```\n",
+    "+ `arg1` = chromosome number (must be an integer)\n",
+    "+ `arg2` = path to PLINK binary file (must end in `.bed` extension)\n",
+    "+ `arg3` = path to FBM file (without extensions. If this file doesn't exist, it will be generated)\n",
+    "+ `arg4` = path to output file \n",
+    "+ `arg5` = `thr_r2`, this is the `thr_r2` used by snp_ldsplit. All correlation smaller than `thr_r2` are set to 0\n",
+    "+ `arg6` = `max_r2`, this is the `max_r2` used by snp_ldsplit. This is the maximum acceptable correlation for SNPs in different blocks. \n",
+    "\n",
+    "For example, \n",
+    "\n",
+    "```R\n",
+    "$ Rscript --vanilla ld_split.R 1 my_plink.bed my_plink_fbm regions.txt 0.01 0.3\n",
+    "```"
    ]
   },
   {
@@ -115,9 +135,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.3",
+   "display_name": "Julia 1.11.1",
    "language": "julia",
-   "name": "julia-1.10"
+   "name": "julia-1.11"
   },
   "language_info": {
    "file_extension": ".jl",

--- a/docs/src/man/solveblocks.md
+++ b/docs/src/man/solveblocks.md
@@ -64,8 +64,28 @@ Calling `solveblock` will create 3 files in the directory `outdir/chr` (the `chr
 
 ## Determining `start_bp` and `end_bp`
 
-+ In our papers, we defined each start and end position by adapting the [quasi-independent regions of ldetect](https://bitbucket.org/nygcresearch/ldetect-data/src/master/). 
-+ Given individual level data, one can compute approximately independent LD blocks directly, see [reference](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8696101/) and [R software](https://privefl.github.io/bigsnpr/reference/snp_ldsplit.html).
+There are 2 options:
+
+1. One can defined each start and end position by leveraging existing quasi-independent regions for your target sample. For example, we previously used the European blocks of [ldetect](https://bitbucket.org/nygcresearch/ldetect-data/src/master/). 
+2. Given individual level data, one can compute approximately independent LD blocks directly, see [reference](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8696101/) and [R software](https://privefl.github.io/bigsnpr/reference/snp_ldsplit.html).
+
+For option 2, we provide an [R script](https://github.com/biona001/GhostKnockoffGWAS/blob/main/src/ld_split.R) which can be ran in the terminal (this requires the `R` packages `bigsnpr` and `dplyr`). Usage:
+
+```R
+$ Rscript --vanilla ld_split.R arg1 arg2 arg3 arg4 arg5 arg6
+```
++ `arg1` = chromosome number (must be an integer)
++ `arg2` = path to PLINK binary file (must end in `.bed` extension)
++ `arg3` = path to FBM file (without extensions. If this file doesn't exist, it will be generated)
++ `arg4` = path to output file 
++ `arg5` = `thr_r2`, this is the `thr_r2` used by snp_ldsplit. All correlation smaller than `thr_r2` are set to 0
++ `arg6` = `max_r2`, this is the `max_r2` used by snp_ldsplit. This is the maximum acceptable correlation for SNPs in different blocks. 
+
+For example, 
+
+```R
+$ Rscript --vanilla ld_split.R 1 my_plink.bed my_plink_fbm regions.txt 0.01 0.3
+```
 
 ## A note on run-time
 

--- a/src/ld_split.R
+++ b/src/ld_split.R
@@ -1,0 +1,71 @@
+# usage: Rscript --vanilla manhattan.R arg1 arg2 arg3 arg4 arg5 arg6
+# arg1 = chromosome number (must be an integer)
+# arg2 = path to PLINK binary file (without .bim/bed/fam extension)
+# arg3 = path to FBM file (if this file doesn't exist, it will be generated)
+# arg4 = path to output file 
+# arg5 = thr_r2, this is the thr_r2 used by snp_ldsplit. All correlation
+#        smaller than thr_r2 are set to 0
+# arg6 = max_r2, this is the max_r2 used by snp_ldsplit. This is the maximum 
+#        acceptable correlation for SNPs in different blocks. 
+
+# Description:
+# This R code runs the snp_ldsplit function: https://privefl.github.io/bigsnpr/reference/snp_ldsplit.html
+# It operates directly on PLINK binary files and produces roughly independent
+# blocks stored as a plain text file. Note that it is generally recommended to 
+# run this code with at least 16GB of RAM, possibly more are needed for dense
+# array genotypes. 
+
+# required libraries
+library("bigsnpr")
+library("dplyr")
+
+# enable command line arguments
+args = commandArgs(TRUE)
+chr = as.numeric(args[1])
+plinkfile = args[2]
+fbmfile = args[3]
+outfile = args[4]
+thr_r2 = as.numeric(args[5])
+max_r2 = as.numeric(args[6]) 
+
+# import PLINK data as FBM (file backed matrix) format
+rdsfile <- paste0(fbmfile, ".rds")
+if (!file.exists(rdsfile)){snp_readBed2(plinkfile, backingfile = fbmfile)} 
+x <- snp_attach(rdsfile)
+
+# estimate correlation matrix
+corr <- snp_cor(x$genotypes, infos.pos=x$map$physical.pos, ncores=1)
+
+# compute LD regions
+m <- ncol(corr)
+max_sizes <- c(1000, 1500, 3000, 6000, 10000)
+max_sizes <- max_sizes[max_sizes <= dim(corr)[1]]
+splits <- snp_ldsplit(corr, thr_r2 = thr_r2, min_size = 500, max_size = max_sizes, max_r2 = max_r2)
+
+# run snp_ldsplit with default objective
+splits$cost2 <- sapply(splits$all_size, function(sizes) sum(sizes^2))
+best_split <- splits %>%
+    arrange(cost2 * sqrt(5 + cost)) %>%
+    print() %>%
+    slice(1) %>%
+    print()
+all_size <- best_split$all_size[[1]]
+best_grp <- rep(seq_along(all_size), all_size)
+
+# get position of LD split
+unique_grp <- unique(best_grp)
+start_pos <- integer(length(unique_grp))
+end_pos <- integer(length(unique_grp))
+for (i in seq_along(unique_grp)) {
+  start_pos[i] <- min(which(best_grp == unique_grp[i]))
+  end_pos[i] <- max(which(best_grp == unique_grp[i]))
+}
+
+# save result
+pos <- x$map$physical.pos
+result <- data.frame(
+    chr = rep(chr, length(start_pos)),
+    start = pos[start_pos], 
+    stop = pos[end_pos]
+)
+write.table(result, outfile, row.names = FALSE, quote=FALSE, sep="\t")

--- a/src/ld_split.R
+++ b/src/ld_split.R
@@ -1,7 +1,8 @@
 # usage: Rscript --vanilla manhattan.R arg1 arg2 arg3 arg4 arg5 arg6
 # arg1 = chromosome number (must be an integer)
-# arg2 = path to PLINK binary file (without .bim/bed/fam extension)
-# arg3 = path to FBM file (if this file doesn't exist, it will be generated)
+# arg2 = path to PLINK binary file (must end in `.bed` extension)
+# arg3 = path to FBM file (without extensions. If this file doesn't exist, it
+#        will be generated)
 # arg4 = path to output file 
 # arg5 = thr_r2, this is the thr_r2 used by snp_ldsplit. All correlation
 #        smaller than thr_r2 are set to 0


### PR DESCRIPTION
This PR adds `ld_split.R` and its associated documentation. This function allows users to compute quasi-independent LD blocks starting with individual-level genotype data stored in binary PLINK format. 