### PR TITLE
Run CI on Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.9"
+          - "1.12"
         os:
           - ubuntu-latest
           # - macOS-latest
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.9'
+          version: '1.12'
       - run: | # add unregistered packages first
           julia --project=docs -e '
             using Pkg

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,35 +10,37 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - "1.12"
-        os:
-          - ubuntu-latest
-          # - macOS-latest
-          # - windows-latest
-        arch:
-          - x64
+        include:
+          - version: "1.12"
+            os: ubuntu-latest
+            platform: linux-x64
+          - version: "1.12"
+            os: macos-latest
+            platform: macos-aarch64
+          - version: "1.12"
+            os: macos-15-intel
+            platform: macos-x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
+          arch: default
       - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
           path: ~/.julia/artifacts
-          key: ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          key: ${{ matrix.platform }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.arch }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-${{ matrix.arch }}-test-
-            ${{ runner.os }}-${{ matrix.arch }}-
+            ${{ matrix.platform }}-test-${{ env.cache-name }}-
+            ${{ matrix.platform }}-test-
+            ${{ matrix.platform }}-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
       - run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.9'
+          version: '1.12'
       - run: | # add unregistered packages first
           julia --project=docs -e '
             using Pkg

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -547,7 +547,9 @@ version = "0.2.4"
 
 [[deps.Ghostbasil]]
 deps = ["CxxWrap", "ghostbasil_jll", "libcxxwrap_julia_jll"]
-path = "/Users/biona001/.julia/dev/Ghostbasil.jl"
+git-tree-sha1 = "bb33af237d3858c6d5d47fd5cc62c2a167bd5837"
+repo-rev = "main"
+repo-url = "https://github.com/biona001/Ghostbasil.jl"
 uuid = "42a9b20f-2d23-465a-b7ed-975dbff4a4d6"
 version = "0.0.2"
 
@@ -1498,7 +1500,9 @@ version = "1.4.2+0"
 
 [[deps.ghostbasil_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "libcxxwrap_julia_jll"]
-path = "/Users/biona001/.julia/dev/ghostbasil_jll"
+git-tree-sha1 = "7fddcd6617d266818e6c4f9c7fde0a8a2cc18802"
+repo-rev = "main"
+repo-url = "https://github.com/biona001/ghostbasil_jll.jl"
 uuid = "caeec347-1c5e-53ac-8e86-7f5e1a690164"
 version = "0.0.16+0"
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,4 +6,4 @@ This is package for performing knockoff-based analysis of GWAS summary statistic
 
 !!! warning
 
-    The Julia package supports Linux and macOS with Julia 1.10 or newer when a matching `Ghostbasil.jl`/`ghostbasil_jll` artifact is installed. Windows is not supported. Prebuilt app downloads may cover fewer platforms than the Julia package; see the downloads page for currently published bundles.
+    The Julia package supports Linux and macOS on Julia 1.10 and 1.12 when a matching `Ghostbasil.jl`/`ghostbasil_jll` artifact is installed. Windows is not supported. Julia 1.11 is not currently supported by the published `ghostbasil_jll` artifacts. Prebuilt app downloads may cover fewer platforms than the Julia package; see the downloads page for currently published bundles.


### PR DESCRIPTION
Updates GitHub Actions workflows from Julia 1.9 to Julia 1.12 so CI matches the supported Ghostbasil/GhostKnockoffGWAS runtime.