### PR TITLE
Add binary build workflow

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,102 @@
+name: Build binaries
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            julia-arch: x64
+            target: linux-x86_64
+          - os: ubuntu-24.04-arm
+            julia-arch: aarch64
+            target: linux-aarch64
+          - os: macos-15-intel
+            julia-arch: x64
+            target: macos-x86_64
+          - os: macos-15
+            julia-arch: aarch64
+            target: macos-aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: "1.10"
+          arch: ${{ matrix.julia-arch }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.julia/artifacts
+            ~/.julia/compiled
+          key: ${{ runner.os }}-${{ matrix.julia-arch }}-packagecompiler-${{ hashFiles('Project.toml', 'Manifest.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.julia-arch }}-packagecompiler-
+            ${{ runner.os }}-${{ matrix.julia-arch }}-
+
+      - name: Prepare build environment
+        run: |
+          julia --project=/tmp/citlasso-build-env -e '
+            using Pkg
+            Pkg.activate("/tmp/citlasso-build-env")
+            Pkg.add("PackageCompiler")
+            Pkg.develop(url="https://github.com/biona001/ghostbasil_jll.jl")
+            Pkg.develop(url="https://github.com/biona001/Ghostbasil.jl")
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()
+            Pkg.precompile()
+          '
+
+      - name: Build app
+        run: |
+          mkdir -p build
+          julia --project=/tmp/citlasso-build-env -e '
+            using PackageCompiler, CITLasso
+            src = normpath(pathof(CITLasso), "../..")
+            app_dir = joinpath(pwd(), "build", "cit-lasso-${{ matrix.target }}")
+            precompile_script = normpath(pathof(CITLasso), "../precompile.jl")
+            create_app(src, app_dir;
+                include_lazy_artifacts=true,
+                force=true,
+                precompile_execution_file=precompile_script,
+                executables=[
+                    "cit-lasso" => "julia_main",
+                    "solveblock" => "julia_solveblock",
+                ],
+            )
+          '
+
+      - name: Smoke test
+        run: |
+          ./build/cit-lasso-${{ matrix.target }}/bin/cit-lasso --help
+          ./build/cit-lasso-${{ matrix.target }}/bin/solveblock --help
+
+      - name: Archive app
+        run: tar -czf CIT-Lasso-${{ matrix.target }}.tar.gz -C build cit-lasso-${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: CIT-Lasso-${{ matrix.target }}
+          path: CIT-Lasso-${{ matrix.target }}.tar.gz
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: CIT-Lasso-${{ matrix.target }}.tar.gz


### PR DESCRIPTION
## Summary
- add a manual/tag/release-triggered Build binaries workflow
- build Linux x86_64, Linux ARM64, macOS Intel, and macOS Apple Silicon tarballs
- upload tarballs as workflow artifacts on every run
- attach generated tarballs to GitHub Releases when run from a version tag or a published release

## Platform notes
- Windows is not included because ghostbasil_jll does not currently publish Windows artifacts.
- musl/Alpine-style Linux is not included in this workflow because the standard GitHub-hosted runners are glibc-based; the workflow smoke-tests only native runner platforms.

## Testing
- parsed workflow matrix locally with Python YAML
- not run end-to-end; workflow-only split from PR #54